### PR TITLE
Fix compilation error on armhf with `printf()` and `time_t`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log for `aprs-weather-submit`
 
 ## Version 1.8.1
+<time datetime="2024-11-03">November 3, 2024</time>
 Fixed a bug where compilation would fail on `armhf` platforms due to an improper cast when `printf()`-ing a `time_t`.  It's a `long long int` on that platform, while `printf()` was expecting a `long int` instead.
 
 ## Version 1.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log for `aprs-weather-submit`
 
+## Version 1.8.1
+Fixed a bug where compilation would fail on `armhf` platforms due to an improper cast when `printf()`-ing a `time_t`.  It's a `long long int` on that platform, while `printf()` was expecting a `long int` instead.
+
 ## Version 1.8
 <time datetime="2024-10-31T22:35:00-04:00">October 31, 2024</time>
 *   Converted the APRS-IS socket from blocking to non-blocking, with a default timeout of 15 seconds before the connection is aborted.  Thanks to [DL9SEC](https://www.dl9sec.de) for pointing this out.

--- a/configure.ac
+++ b/configure.ac
@@ -17,7 +17,7 @@ dnl
 dnl  You should have received a copy of the GNU Affero General Public License
 dnl  along with this program. If not, see <http://gnu.org/licenses/agpl-3.0.html>.
 
-AC_INIT([aprs-weather-submit], [1.8], [https://github.com/rhymeswithmogul/aprs-weather-submit/])
+AC_INIT([aprs-weather-submit], [1.8.1], [https://github.com/rhymeswithmogul/aprs-weather-submit/])
 AM_INIT_AUTOMAKE([foreign subdir-objects -Wall -Werror])
 AC_PREREQ
 AC_PROG_INSTALL

--- a/src/aprs-is.c
+++ b/src/aprs-is.c
@@ -131,7 +131,7 @@ sendPacket (const char* const restrict server,
 		char* timeoutText = malloc(BUFSIZE);
 		if (timeout > 0)
 		{
-			snprintf(timeoutText, BUFSIZE - 1, " (timeout %ld seconds)", timeout);
+			snprintf(timeoutText, BUFSIZE - 1, " (timeout %jd seconds)", (intmax_t)timeout);
 		}
 		else
 		{

--- a/src/main.h
+++ b/src/main.h
@@ -28,7 +28,7 @@ with this program.  If not, see <https://www.gnu.org/licenses/agpl-3.0.html>.
 #endif
 
 #ifndef VERSION
-#define VERSION "1.8"
+#define VERSION "1.8.1"
 #endif
 
 /* We don't support networking on DOS at this time.


### PR DESCRIPTION
This commit fixes a bug I noticed on the armhf platform.  I guess `time_t` might only be 32-bits, so to work around this, I cast it to an `intmax_t` before printing.