### PR TITLE
Add device type identifier

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,1 @@
-Colin Cogle, KC1HBK <colin@colincogle.name>
+Colin Cogle, W1DNS <colin@colincogle.name>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log for `aprs-weather-submit`
 
+## Next version
+
 ## Version 1.8.2
 <time datetime="2024-11-13">November 13, 2024</time>
 - Fixed a bug where v1.8.1 would not handle timeouts correctly using the Win32 API.  macOS and Linux users are not affected.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log for `aprs-weather-submit`
 
 ## Next version
+Not yet released.
+- Added the `Z` device type field, as noted in [**APRS version 1.2.1 WEATHER UPDATES TO THE SPEC**](https://www.aprs.org/aprs12/weather-new.txt).
 
 ## Version 1.8.2
 <time datetime="2024-11-13">November 13, 2024</time>

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 # aprs-weather-submit
-# Copyright (c) 2019-2024 Colin Cogle <colin@colincogle.name>
+# Copyright (c) 2019-2025 Colin Cogle <colin@colincogle.name>
 #
 # This file, Makefile.am, is part of aprs-weather-submit.
 # <https://github.com/rhymeswithmogul/aprs-weather-submit>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,19 +1,7 @@
 # aprs-weather-submit news
 
-This file details all of the user-facing changes that are in versions 1.8 of aprs-weather-submit. For more details, please consult the CHANGELOG file or this project's GitHub page.
+This file details all of the user-facing changes that are in versions 1.9 of aprs-weather-submit. For more details, please consult the CHANGELOG file or this project's GitHub page.
 
-## Graceful failure
-
-In version 1.7.2 and older, the app would hang almost indefinitely if the remote APRS-IS server did not respond.  This version fixes that by converting to non-blocking sockets, so that if your APRS-IS server does not respond in a timely manner (for whatever reason), the connection will fail gracefully.
-
-Likewise, there is a new parameter, `--timeout`, that will let you specify a timeout value, if you don't like my default of fifteen seconds.
-
-If you want the old behavior, specify `--timeout 0`.
-
-Thanks to [DL9SEC](https://www.dl9sec.de) for pointing out this behavior, and I suppose thanks are due to the APRS Tier 2 network for having some servers down long enough for this bug to get pointed out.
-
-
-## Building without APRS-IS support
-
-I'd always given users the option to build a custom version without APRS-IS support by specifying `./configure --disable-aprs-is`.  However, that broke at some point.  This option now works as intended.
+## Device type identifier.
+The `Z` device type identifier is now supported by using the `-Z`/`--device-type` parameter.  The device type is any two characters.
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # aprs-weather-submit
-# Copyright (c) 2019-2024 Colin Cogle <colin@colincogle.name>
+# Copyright (c) 2019-2025 Colin Cogle <colin@colincogle.name>
 #
 # This file, autogen.sh, is part of aprs-weather-submit.
 # <https://github.com/rhymeswithmogul/aprs-weather-submit>

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 dnl  aprs-weather-submit
-dnl  Copyright (c) 2019-2024 Colin Cogle <colin@colincogle.name>
+dnl  Copyright (c) 2019-2025 Colin Cogle <colin@colincogle.name>
 dnl
 dnl  This file, configure.ac, is part of aprs-weather-submit.
 dnl  <https://github.com/rhymeswithmogul/aprs-weather-submit>
@@ -17,7 +17,7 @@ dnl
 dnl  You should have received a copy of the GNU Affero General Public License
 dnl  along with this program. If not, see <http://gnu.org/licenses/agpl-3.0.html>.
 
-AC_INIT([aprs-weather-submit], [1.8.2], [https://github.com/rhymeswithmogul/aprs-weather-submit/])
+AC_INIT([aprs-weather-submit], [1.8.2-testingtocall], [https://github.com/rhymeswithmogul/aprs-weather-submit/])
 AM_INIT_AUTOMAKE([foreign subdir-objects -Wall -Werror])
 AC_PREREQ
 AC_PROG_INSTALL

--- a/configure.ac
+++ b/configure.ac
@@ -17,7 +17,7 @@ dnl
 dnl  You should have received a copy of the GNU Affero General Public License
 dnl  along with this program. If not, see <http://gnu.org/licenses/agpl-3.0.html>.
 
-AC_INIT([aprs-weather-submit], [1.8.2-testingtocall], [https://github.com/rhymeswithmogul/aprs-weather-submit/])
+AC_INIT([aprs-weather-submit], [1.9-dev], [https://github.com/rhymeswithmogul/aprs-weather-submit/])
 AM_INIT_AUTOMAKE([foreign subdir-objects -Wall -Werror])
 AC_PREREQ
 AC_PROG_INSTALL

--- a/debian/copyright
+++ b/debian/copyright
@@ -4,7 +4,7 @@ Upstream-Contact: Colin Cogle <colin@colincogle.name>
 Source: https://github.com/rhymeswithmogul/aprs-weather-submit/
 
 Files: *
-Copyright: 2019-2024 Colin Cogle <colin@colincogle.name>
+Copyright: 2019-2025 Colin Cogle <colin@colincogle.name>
 License: AGPL-3+
  This program is free software: you can redistribute it and/or modify it under
  the terms of the GNU Affero General Public License as published by the Free

--- a/make.bat
+++ b/make.bat
@@ -1,6 +1,6 @@
 @ECHO OFF
 REM aprs-weather-submit
-REM Copyright (c) 2019-2024 Colin Cogle (colin@colincogle.name)
+REM Copyright (c) 2019-2025 Colin Cogle (colin@colincogle.name)
 REM
 REM This file, make-dos.bat, is part of aprs-weather-submit.
 REM (https://github.com/rhymeswithmogul/aprs-weather-submit)

--- a/man/aprs-weather-submit.man
+++ b/man/aprs-weather-submit.man
@@ -177,6 +177,7 @@ If you specify a value outside of this range, it will be reduced (that is, a rep
 (APRS 1.2)
 The water level above or below the flood stage or mean tide.
 You may report numbers from \-99.9 feet to 99.9 feet, with a resolution of 0.1 feet.
+Note that this data is technically part of the comment field and may not be parsed by all APRS decoders as weather data.
 .TP
 .BR \-g ", " \-\-gust =\fISPEED\fP
 The peak wind speed measured in the past five minutes.
@@ -225,17 +226,20 @@ If both \fB-t\fP and \fB-T\fP are specified, the last option specified will be r
 (APRS 1.2)
 The battery voltage.
 You may report voltages of up to 99.9 volts, with a resolution of one-tenth of a volt.
+Note that this data is technically part of the comment field and may not be parsed by all APRS decoders as weather data.
 .TP
 .BR \-X ", " \-\-radiation =\fINANOSIEVERTS\fP
 (APRS 1.2)
 The current level of nuclear radiation.
 You may report readings of up to 99,000,000,000 nanosieverts per hour, though the resolution of the value put into your report varies based on orders of magnitude.
 Consult the APRS 1.2 specification for full details.
+Note that this data is technically part of the comment field and may not be parsed by all APRS decoders as weather data.
 .TP
 .BR \-Z ", " \-\-device\-type =\fIDEVICE-TYPE\fP
 (APRS 1.2.1)
 Exactly two characters to identify the type of device sending this information.
 The device types are not defined in the APRS specification and are implementation-specific.
+Note that this data is technically part of the comment field and may not be parsed by all APRS decoders as weather data.
 .SH EXAMPLES
 .PP
 If you were operating the ARRL's (theoretical) weather station at their headquarters and wanted to submit a temperature of 68 degrees Fahrenheit, no rainfall, and a westerly wind at about five miles per hour, use this command:

--- a/man/aprs-weather-submit.man
+++ b/man/aprs-weather-submit.man
@@ -18,7 +18,7 @@
 .\"
 .\" (This page is best viewed with the command: groff -man)
 .\"
-.TH aprs\-weather\-submit 1 "2024-10-31" "Version 1.8" "aprs-weather-submit General Help"
+.TH aprs\-weather\-submit 1 "2025-02-14" "Version 1.9-dev" "aprs-weather-submit General Help"
 .SH NAME
 aprs\-weather\-submit \- manually submit weather station data to the APRS-IS network
 .SH DESCRIPTION
@@ -70,6 +70,8 @@ This command-line app will manually submit APRS 1.2.1-compliant weather informat
 .IR VOLTS " ]\:"
 .RB [ " \-X "
 .IR NANOSIEVERTS " ]\:"
+.RB [ " \-Z "
+.IR DEVICE_TYPE " ]\:"
 .RB [ " \-Q "
 .RB | " \-M "
 .IR COMMENT " ]\:"
@@ -229,6 +231,11 @@ You may report voltages of up to 99.9 volts, with a resolution of one-tenth of a
 The current level of nuclear radiation.
 You may report readings of up to 99,000,000,000 nanosieverts per hour, though the resolution of the value put into your report varies based on orders of magnitude.
 Consult the APRS 1.2 specification for full details.
+.TP
+.BR \-Z ", " \-\-device\-type =\fIDEVICE-TYPE\fP
+(APRS 1.2.1)
+Exactly two characters to identify the type of device sending this information.
+The device types are not defined in the APRS specification and are implementation-specific.
 .SH EXAMPLES
 .PP
 If you were operating the ARRL's (theoretical) weather station at their headquarters and wanted to submit a temperature of 68 degrees Fahrenheit, no rainfall, and a westerly wind at about five miles per hour, use this command:
@@ -310,7 +317,7 @@ APRS Version 1.2.1, "Weather Updates to the Spec" (24 Mar 2011)
 .UE
 
 .SH AUTHOR AND COPYRIGHT
-.BR aprs\-weather\-submit ", version 1.8"
+.BR aprs\-weather\-submit ", version 1.9-dev"
 .br
 Copyright (c) 2019-2025 Colin Cogle.
 .br
@@ -327,4 +334,4 @@ Bug reports and contributions should be made on
 this project's GitHub page.
 .UE
 .PP
-QRT. 73 de KC1HBK
+QRT. 73 de W1DNS

--- a/man/aprs-weather-submit.man
+++ b/man/aprs-weather-submit.man
@@ -1,5 +1,5 @@
 .\" aprs-weather-submit
-.\" Copyright (c) 2019-2024 Colin Cogle
+.\" Copyright (c) 2019-2025 Colin Cogle
 .\"
 .\" This file, aprs-weather-submit.1, is part of aprs-weather-submit.
 .\" 
@@ -312,7 +312,7 @@ APRS Version 1.2.1, "Weather Updates to the Spec" (24 Mar 2011)
 .SH AUTHOR AND COPYRIGHT
 .BR aprs\-weather\-submit ", version 1.8"
 .br
-Copyright (c) 2019-2024 Colin Cogle.
+Copyright (c) 2019-2025 Colin Cogle.
 .br
 This program comes with ABSOLUTELY NO WARRANTY.
 This is free software, and you are welcome to redistribute it under certain conditions.

--- a/src/aprs-is.c
+++ b/src/aprs-is.c
@@ -1,6 +1,6 @@
 /*
  aprs-weather-submit
- Copyright (c) 2019-2024 Colin Cogle <colin@colincogle.name>
+ Copyright (c) 2019-2025 Colin Cogle <colin@colincogle.name>
 
  This file, aprs-is.c, is part of aprs-weather-submit.
  <https://github.com/rhymeswithmogul/aprs-weather-submit>

--- a/src/aprs-is.h
+++ b/src/aprs-is.h
@@ -1,6 +1,6 @@
 /*
  aprs-weather-submit
- Copyright (c) 2019-2024 Colin Cogle <colin@colincogle.name>
+ Copyright (c) 2019-2025 Colin Cogle <colin@colincogle.name>
  
  This file, aprs-is.h, is part of aprs-weather-submit.
  <https://github.com/rhymeswithmogul/aprs-weather-submit>

--- a/src/aprs-wx.c
+++ b/src/aprs-wx.c
@@ -65,6 +65,7 @@ packetConstructor (APRSPacket* const p)
 	strcpy(p->snowfallLast24Hours, "...");
 	strcpy(p->comment, "");
 	strcpy(p->icon, "/_");	/* the default icon, (WX) */
+	strcpy(p->deviceType, "");
 	return;
 }
 
@@ -354,6 +355,12 @@ printAPRSPacket (APRSPacket* restrict const p, char* restrict const ret,
 	{
 		strcat(result, "V");
 		strcat(result, p->voltage);
+	}
+
+	if (notNull(p->deviceType))
+	{
+		strcat(result, "Z");
+		strcat(result, p->deviceType);
 	}
 
 	if (notNull(p->snowfallLast24Hours))

--- a/src/aprs-wx.c
+++ b/src/aprs-wx.c
@@ -1,6 +1,6 @@
 /*
  aprs-weather-submit
- Copyright (c) 2019-2024 Colin Cogle <colin@colincogle.name>
+ Copyright (c) 2019-2025 Colin Cogle <colin@colincogle.name>
 
  This file, aprs-wx.c, is part of aprs-weather-submit.
  <https://github.com/rhymeswithmogul/aprs-weather-submit>
@@ -276,7 +276,7 @@ printAPRSPacket (APRSPacket* restrict const p, char* restrict const ret,
 		snprintf_verify(snprintf(
 			result, 48,
 		/*	 header_________ timestamp____siLNLEscWDWST*/
-			"%s>APRS,TCPIP*:@%.2d%.2d%.2dz%c%s%s%c%c%cC",
+			"%s>APRSWX,TCPIP*:@%.2d%.2d%.2dz%c%s%s%c%c%cC",
 			p->callsign, now->tm_mday, now->tm_hour, now->tm_min, p->icon[0],
 			p->latitude, p->longitude, p->icon[1], p->windDirection[0], p->windSpeed[0]
 		));
@@ -285,7 +285,7 @@ printAPRSPacket (APRSPacket* restrict const p, char* restrict const ret,
 		snprintf_verify(snprintf(
 			result, 61,
 		/*	 header_________ timestamp____LNsiLEscWD/WS*/
-			"%s>APRS,TCPIP*:@%.2d%.2d%.2dz%s%c%s%c%s/%s",
+			"%s>APRSWX,TCPIP*:@%.2d%.2d%.2dz%s%c%s%c%s/%s",
 			p->callsign, now->tm_mday, now->tm_hour, now->tm_min, p->latitude,
 			p->icon[0], p->longitude, p->icon[1], p->windDirection, p->windSpeed
 		));

--- a/src/aprs-wx.c
+++ b/src/aprs-wx.c
@@ -344,8 +344,8 @@ printAPRSPacket (APRSPacket* restrict const p, char* restrict const ret,
 		strcat(result, p->radiation);
 	}
 
-	/* F is required by APRS 1.2 if voltage is present  */
-	if (notNull(p->waterLevel) || notNull(p->voltage))
+	/* F is required by APRS 1.2.1 if voltage or device type are present  */
+	if (notNull(p->waterLevel) || notNull(p->voltage) || notNull(p->deviceType))
 	{
 		strcat(result, "F");
 		strcat(result, p->waterLevel);

--- a/src/aprs-wx.h
+++ b/src/aprs-wx.h
@@ -46,6 +46,7 @@ typedef struct APRSPacket
 	char radiation[4];
 	char waterLevel[5];
 	char voltage[4];
+	char deviceType[3];
 	char comment[MAX_COMMENT_LENGTH + 1];
 	char icon[3];
 } APRSPacket;

--- a/src/aprs-wx.h
+++ b/src/aprs-wx.h
@@ -1,6 +1,6 @@
 /*
  aprs-weather-submit
- Copyright (c) 2019-2024 Colin Cogle <colin@colincogle.name>
+ Copyright (c) 2019-2025 Colin Cogle <colin@colincogle.name>
  
  This file, aprs-wx.h, is part of aprs-weather-submit.
  <https://github.com/rhymeswithmogul/aprs-weather-submit>

--- a/src/c99math.c
+++ b/src/c99math.c
@@ -1,6 +1,6 @@
 /*
  aprs-weather-submit
- Copyright (c) 2019-2024 Colin Cogle <colin@colincogle.name>
+ Copyright (c) 2019-2025 Colin Cogle <colin@colincogle.name>
 
  This file, c99math.h, is part of aprs-weather-submit.
  <https://github.com/rhymeswithmogul/aprs-weather-submit>

--- a/src/c99math.h
+++ b/src/c99math.h
@@ -1,6 +1,6 @@
 /*
  aprs-weather-submit
- Copyright (c) 2019-2024 Colin Cogle <colin@colincogle.name>
+ Copyright (c) 2019-2025 Colin Cogle <colin@colincogle.name>
  
  This file, c99math.h, is part of aprs-weather-submit.
  <https://github.com/rhymeswithmogul/aprs-weather-submit>

--- a/src/help.c
+++ b/src/help.c
@@ -35,11 +35,11 @@ version (void)
 	/* Per the FreeDOS standards, we should emit one line with license
 	 * information. */
 	puts(".\n\
-Copyright (c) 2019-2024 Colin Cogle.\n\
+Copyright (c) 2019-2025 Colin Cogle.\n\
 This program is free software (GNU Affero General Public License v3).");
 #else
 	puts(".\n\
-Copyright (c) 2019-2024 Colin Cogle.\n\
+Copyright (c) 2019-2025 Colin Cogle.\n\
 This program comes with ABSOLUTELY NO WARRANTY. This is free software, and you\n\
 are welcome to redistribute it under certain conditions.  See the GNU Affero\n\
 General Public License (version 3.0) for more details.");

--- a/src/help.c
+++ b/src/help.c
@@ -120,7 +120,8 @@ Required parameters:\n\
 	-t, --temperature              Temperature (degrees Fahrenheit).\n\
 	-T, --temperature-celsius      Temperature (degrees Celsius).\n\
 	-V, --voltage                  Battery voltage of your weather station.\n\
-	-X, --radiation                Radiation levels (nanosieverts per hour).\n\n\
+	-X, --radiation                Radiation levels (nanosieverts per hour).\n\
+	-Z, --device-type              A two-character device type code.\n\n\
 Find this project online at https://github.com/rhymeswithmogul/aprs-weather-submit\n");
 #else /* DOS build -- son't forget to wrap lines at 80 characters */
 	puts("\n\
@@ -153,7 +154,8 @@ Optional parameters (each requires an argument):\n\
 	/t\tTemperature (degrees Fahrenheit).\n\
 	/T\tTemperature (degrees Celsius).\n\
 	/V\tBattery voltage of your weather station.\n\
-	/X\tRadiation levels (nanosieverts per hour).\n\n\
+	/X\tRadiation levels (nanosieverts per hour).\n\
+	/Z\tTwo-character device type identifier.\n\n\
 Find this online at https://github.com/rhymeswithmogul/aprs-weather-submit\n");
 #endif
 	return;

--- a/src/help.h
+++ b/src/help.h
@@ -1,6 +1,6 @@
 /*
  aprs-weather-submit
- Copyright (c) 2019-2024 Colin Cogle <colin@colincogle.name>
+ Copyright (c) 2019-2025 Colin Cogle <colin@colincogle.name>
  
  This file, help.h, is part of aprs-weather-submit.
  <https://github.com/rhymeswithmogul/aprs-weather-submit>

--- a/src/main.c
+++ b/src/main.c
@@ -104,6 +104,7 @@ main (const int argc, const char** argv)
 		{"radiation",               required_argument, 0, 'X'},
 		{"water-level-above-stage", required_argument, 0, 'F'}, /* APRS 1.2 */
 		{"voltage",                 required_argument, 0, 'V'}, /* APRS 1.2 */
+		{"device-type",             required_argument, 0, 'Z'}, /* APRS 1.2.1 addendum */
 		{"icon",                    required_argument, 0, 'i'},
 		{0, 0, 0, 0}
 	};
@@ -132,11 +133,11 @@ main (const int argc, const char** argv)
 	}
 
 #ifdef _DOS
-	while ((c = (char) getopt(argc, (char**)argv, "CH?vI:o:u:d:k:n:e:A:c:S:g:t:T:r:P:p:s:h:b:L:X:F:V:QM:i:")) != -1)
+	while ((c = (char) getopt(argc, (char**)argv, "CH?vI:o:u:d:k:n:e:A:c:S:g:t:T:r:P:p:s:h:b:L:X:F:V:QM:i:Z:")) != -1)
 #elif HAVE_APRSIS_SUPPORT
-	while ((c = (char) getopt_long(argc, (char* const*)argv, "CHvI:o:m:u:d:k:n:e:A:c:S:g:t:T:r:P:p:s:h:b:L:X:F:V:QM:i:", long_options, &option_index)) != -1)
+	while ((c = (char) getopt_long(argc, (char* const*)argv, "CHvI:o:m:u:d:k:n:e:A:c:S:g:t:T:r:P:p:s:h:b:L:X:F:V:QM:i:Z:", long_options, &option_index)) != -1)
 #else
-	while ((c = (char) getopt_long(argc, (char* const*)argv, "CHvk:n:e:A:c:S:g:t:T:r:P:p:s:h:b:L:X:F:V:QM:i:", long_options, &option_index)) != -1)
+	while ((c = (char) getopt_long(argc, (char* const*)argv, "CHvk:n:e:A:c:S:g:t:T:r:P:p:s:h:b:L:X:F:V:QM:i:Z:", long_options, &option_index)) != -1)
 #endif
 	{
 		double x = 0.0;	 /* scratch space */
@@ -575,6 +576,18 @@ main (const int argc, const char** argv)
 						snprintf(packet.voltage, 4, "%.3d", (short)x * 10)
 					);
 				}
+				break;
+
+			/* (APRS 1.2.1 addendum) Device type identifier (-Z | --device-type) */
+			case 'Z':
+				if (strlen(optarg) != 2)
+				{
+					fprintf(stderr, "%s: option '-%c' must be exactly two characters.\n", argv[0], optopt);
+					return EXIT_FAILURE;
+				}
+				snprintf_verify(
+					snprintf(packet.deviceType, strlen(optarg)+1, "%s", optarg)
+				);
 				break;
 
 			/* -Q | --no-comment: Suppress our user agent, if desired. */

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,6 @@
 /*
  aprs-weather-submit
- Copyright (c) 2019-2024 Colin Cogle <colin@colincogle.name>
+ Copyright (c) 2019-2025 Colin Cogle <colin@colincogle.name>
 
  This file, main.c, is part of aprs-weather-submit.
  <https://github.com/rhymeswithmogul/aprs-weather-submit>

--- a/src/main.c
+++ b/src/main.c
@@ -585,8 +585,9 @@ main (const int argc, const char** argv)
 					fprintf(stderr, "%s: option '-%c' must be exactly two characters.\n", argv[0], optopt);
 					return EXIT_FAILURE;
 				}
+
 				snprintf_verify(
-					snprintf(packet.deviceType, strlen(optarg)+1, "%s", optarg)
+					snprintf(packet.deviceType, 3, "%s", optarg)
 				);
 				break;
 

--- a/src/main.h
+++ b/src/main.h
@@ -1,6 +1,6 @@
 /*
  aprs-weather-submit
- Copyright (c) 2019-2024 Colin Cogle <colin@colincogle.name>
+ Copyright (c) 2019-2025 Colin Cogle <colin@colincogle.name>
 
  This file, main.h, is part of aprs-weather-submit.
  <https://github.com/rhymeswithmogul/aprs-weather-submit>
@@ -28,7 +28,7 @@ with this program.  If not, see <https://www.gnu.org/licenses/agpl-3.0.html>.
 #endif
 
 #ifndef VERSION
-#define VERSION "1.8.2"
+#define VERSION "1.8.2_testing-tocall"
 #endif
 
 /* We don't support networking on DOS at this time.

--- a/src/main.h
+++ b/src/main.h
@@ -28,7 +28,7 @@ with this program.  If not, see <https://www.gnu.org/licenses/agpl-3.0.html>.
 #endif
 
 #ifndef VERSION
-#define VERSION "1.8.2_testing-tocall"
+#define VERSION "1.9-dev"
 #endif
 
 /* We don't support networking on DOS at this time.


### PR DESCRIPTION
The APRS 1.2.1 addendum defines a two-character device type identifier as letter `Z`.  This pull request adds it.

It also clarifies via the man page that this new data is technically in the comment field, so sites like APRS.fi and APRS.to will parse this as a comment.

Closes: #20 