### PR TITLE
Replace gmtime() with gmtime_r().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next version
 Not yet released.
 - Added the `Z` device type field, as noted in [**APRS version 1.2.1 WEATHER UPDATES TO THE SPEC**](https://www.aprs.org/aprs12/weather-new.txt).
+- Fixed a low-severity [security bug involving the use of `gmtime()`](https://github.com/rhymeswithmogul/aprs-weather-submit/issues/25).  This has the limited potential to be unsafe, so I replaced it with a call to `gmtime_r()`.
 
 ## Version 1.8.2
 <time datetime="2024-11-13">November 13, 2024</time>

--- a/src/aprs-wx.c
+++ b/src/aprs-wx.c
@@ -22,7 +22,7 @@ with this program.  If not, see <https://www.gnu.org/licenses/agpl-3.0.html>.
 #include <stdio.h>    /* fprintf(), printf(), snprintf(), fputs() */
 #include <string.h>   /* strcpy(), strcat(), strlen() */
 #include <math.h>     /* floor(), round(), pow(), fabs() */
-#include <time.h>     /* struct tm, time_t, time(), gmtime() */
+#include <time.h>     /* struct tm, time_t, time(), gmtime_r() */
 #include <stdint.h>   /* uint32_t */
 
 #include "main.h"     /* PACKAGE, VERSION, BUFSIZE, snprintf_verify() */
@@ -266,7 +266,8 @@ printAPRSPacket (APRSPacket* restrict const p, char* restrict const ret,
 {
 	char       result[BUFSIZE] = "\0";
 	time_t     t               = time(NULL);
-	struct tm* now             = gmtime(&t); /* APRS uses GMT */
+	struct tm  now;
+	gmtime_r(&t, &now); /* APRS uses GMT */
 
 	if (compressPacket == COMPRESSED_PACKET)
 	{
@@ -278,7 +279,7 @@ printAPRSPacket (APRSPacket* restrict const p, char* restrict const ret,
 			result, 48,
 		/*	 header_________ timestamp____siLNLEscWDWST*/
 			"%s>APRS,TCPIP*:@%.2d%.2d%.2dz%c%s%s%c%c%cC",
-			p->callsign, now->tm_mday, now->tm_hour, now->tm_min, p->icon[0],
+			p->callsign, now.tm_mday, now.tm_hour, now.tm_min, p->icon[0],
 			p->latitude, p->longitude, p->icon[1], p->windDirection[0], p->windSpeed[0]
 		));
 	}
@@ -287,7 +288,7 @@ printAPRSPacket (APRSPacket* restrict const p, char* restrict const ret,
 			result, 61,
 		/*	 header_________ timestamp____LNsiLEscWD/WS*/
 			"%s>APRS,TCPIP*:@%.2d%.2d%.2dz%s%c%s%c%s/%s",
-			p->callsign, now->tm_mday, now->tm_hour, now->tm_min, p->latitude,
+			p->callsign, now.tm_mday, now.tm_hour, now.tm_min, p->latitude,
 			p->icon[0], p->longitude, p->icon[1], p->windDirection, p->windSpeed
 		));
 	}


### PR DESCRIPTION
This commit fixes a security issue, as discovered by code scanning. The call to `gmtime()` may not be thread-safe under all circumstances, so to prevent issues, I replaced it with a call to `gmtime_r()`.

Fixes: #25 

Format: markdown
Issue: 25
Reviewer: github