### PR TITLE
Switch to using our assigned TOCALL.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## Version 1.9
 Not yet released.
+* [We have our own TOCALL destination!](https://github.com/aprsorg/aprs-deviceid/issues/192)  This app can now identify itself using the `APWXS?` destination, so that the various APRS tracking sites can identify this app without the user agent.
+- In addition to the above, anyone who forks this project can now easily pick their own TOCALL at compile-time by editing the `TOCALL` macro in `main.h` or supplying `-DTOCALL=APZxxx` in `$CFLAGS`.
 - Added the `Z` device type field, as noted in [**APRS version 1.2.1 WEATHER UPDATES TO THE SPEC**](https://www.aprs.org/aprs12/weather-new.txt).
 - Fixed a low-severity [security bug involving the use of `gmtime()`](https://github.com/rhymeswithmogul/aprs-weather-submit/issues/25).  This has the limited potential to be unsafe, so I replaced it with a call to `gmtime_r()`.
-- Anyone who forks this project can now easily pick their own TOCALL at compile-time by editing the `TOCALL` macro in `main.h` or supplying `-DTOCALL=APZxxx` in `$CFLAGS`.
 
 ## Version 1.8.2
 <time datetime="2024-11-13">November 13, 2024</time>

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,11 @@
 
 This file details all of the user-facing changes that are in versions 1.9 of aprs-weather-submit. For more details, please consult the CHANGELOG file or this project's GitHub page.
 
+## We have our own TOCALL now!
+`aprs-weather-submit` will identify itself using the `APWXS` TOCALL destination.  Most APRS hardware and software has its own TOCALL for statistical, tracking, and filtering purposes, and now I do as well.
+
+If you are a developer forking this project, you are welcome to use your own TOCALL or pick from the reserved experimental range.  Directions for changing it are located in `main.h`.
+
 ## Device type identifier.
 The `Z` device type identifier is now supported by using the `-Z`/`--device-type` parameter.  The device type is any two characters.
 

--- a/src/main.h
+++ b/src/main.h
@@ -31,11 +31,16 @@ with this program.  If not, see <https://www.gnu.org/licenses/agpl-3.0.html>.
 #define VERSION "1.9-dev"
 #endif
 
-/* If you customize this app so much that it becomes your own thing,
+/* Official builds of aprs-weather-submit may use the assigned TOCALL
+   destination of "APWXS?" (where the question mark may be used for a
+   version number, which I currently do not use).
+
+   If you customize this app so much that it becomes your own thing,
    I ask that you change the TOCALL to something else.  APZxxx (where
-   "xxx" is anything) is reserved for experimentation. */
+   "xxx" is anything) is reserved for experimentation.
+*/
 #ifndef TOCALL
-#define TOCALL "APRS"
+#define TOCALL "APWXS"
 #endif
 
 /* We don't support networking on DOS at this time.


### PR DESCRIPTION
The APRS registry [has issued us `APWXS?`](https://github.com/aprsorg/aprs-deviceid/issues/192).  This app now uses that for all packets sent.

If you are a developer forking my code, you can edit this TOCALL value in `main.h` and use one of your own choosing.

Closes: 19
Format: markdown
Issue: 19
Milestone: v1.9
Reviewer: github
Tracker: github