### PR TITLE
Add PACKAGE_URL for Autoconf

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -17,7 +17,7 @@ dnl
 dnl  You should have received a copy of the GNU Affero General Public License
 dnl  along with this program. If not, see <http://gnu.org/licenses/agpl-3.0.html>.
 
-AC_INIT([aprs-weather-submit], [1.9-dev], [https://github.com/rhymeswithmogul/aprs-weather-submit/])
+AC_INIT([aprs-weather-submit], [1.9-dev], [https://github.com/rhymeswithmogul/aprs-weather-submit/issues], [], [https://github.com/rhymeswithmogul/aprs-weather-submit/])
 AM_INIT_AUTOMAKE([foreign subdir-objects -Wall -Werror])
 AC_PREREQ
 AC_PROG_INSTALL


### PR DESCRIPTION
Thought I did that previously, but it turns out [the parameters to `AC_INIT` are](https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.72/html_node/Initializing-configure.html#AC_005fINIT), in order:

1. PACKAGE_NAME
2. PACKAGE_VERSION
3. PACKAGE_BUGREPORT
4. PACKAGE_TARNAME, and
5. PACKAGE_URL

So, there we go.  Fixed.

Format: markdown
Reviewer: github