### PR TITLE
Fall back to gmtime() for DOS builds.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log for `aprs-weather-submit`
 
+## Version 2.0.1
+Not yet released
+- A security change in version 2.0 would not compile on DOS because `gmtime_r()` isn't part of the C99 standard.  Now, for DOS platforms, [we revert to using `gmtime()`](https://github.com/rhymeswithmogul/aprs-weather-submit/issues/36).
+
 ## Version 2.0
 <time datetime="2025-05-15">May 15, 2025</time>
 - [We have our own TOCALL destination!](https://github.com/aprsorg/aprs-deviceid/issues/192)  This app can now identify itself using the `APWXS?` destination, so that the various APRS tracking sites can identify this app without the user agent.  I felt that was worthy of a major version bump!

--- a/src/aprs-wx.c
+++ b/src/aprs-wx.c
@@ -22,7 +22,7 @@ with this program.  If not, see <https://www.gnu.org/licenses/agpl-3.0.html>.
 #include <stdio.h>    /* fprintf(), printf(), snprintf(), fputs() */
 #include <string.h>   /* strcpy(), strcat(), strlen() */
 #include <math.h>     /* floor(), round(), pow(), fabs() */
-#include <time.h>     /* struct tm, time_t, time(), gmtime_r() */
+#include <time.h>     /* struct tm, time_t, time(), gmtime(), gmtime_r() */
 #include <stdint.h>   /* uint32_t */
 
 #include "main.h"     /* PACKAGE, VERSION, BUFSIZE, snprintf_verify() */
@@ -266,8 +266,12 @@ printAPRSPacket (APRSPacket* restrict const p, char* restrict const ret,
 {
 	char       result[BUFSIZE] = "\0";
 	time_t     t               = time(NULL);
+	#ifndef _DOS
 	struct tm  now;
 	gmtime_r(&t, &now); /* APRS uses GMT */
+	#else
+	struct tm* now = gmtime(&t);
+	#endif
 
 	if (compressPacket == COMPRESSED_PACKET)
 	{


### PR DESCRIPTION
In version 2.0, we switched to using `gmtime_r()` from `gmtime()` to avoid a possible security issue.  However, this resulted in OpenWatcom failing to build this app.  This is because OpenWatcom only supports the C99 standard, while `gmtime_r()` is a GNU/POSIX extension.

This commit reverts this behavior on DOS platforms by using conditional logic to fall back to `gmtime()`.  It does introduce a small security risk, but without APRS-IS support in DOS at this time, I feel that it is an acceptable tradeoff.

Closes: #36 

Fixes-Bug-Introduced-By: 5e1d35af39a6ec91de944112b8019286bd196db0
Format: markdown
Issue: #36
Tracker: github